### PR TITLE
feat: makes footer sticky

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const year = new Date().getFullYear()
 ---
 
 <footer
-  class="surface children:px-2 children:flex children:flex-col children:w-1/3 children:max-w-[10rem] flex flex-row items-start justify-center gap-0 border-t px-2 py-8 text-sm shadow-none [&>*>*:first-child]:mb-4 [&>*>*:not(:first-child)]:w-fit [&>*>*:not(:first-child)]:py-2"
+  class="surface children:px-2 children:flex children:flex-col children:w-1/3 children:max-w-[10rem] sticky top-[100vh] flex flex-row items-start justify-center gap-0 border-t px-2 py-8 text-sm shadow-none [&>*>*:first-child]:mb-4 [&>*>*:not(:first-child)]:w-fit [&>*>*:not(:first-child)]:py-2"
 >
   <div>
     <span>Legal</span>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -15,7 +15,7 @@ const { title, description, image } = Astro.props as Props
   <head>
     <BaseHead title={title} description={description} image={image} />
   </head>
-  <body class="max-w-full overflow-x-hidden bg-white text-black">
+  <body class="min-h-screen max-w-full overflow-x-hidden bg-white text-black">
     <Header />
     <Main>
       <slot />


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and reference the related issue. -->

- I was reading your blog - particularly about your rehype header anchors. Anyway, I noticed on some pages where the footer wasn't at the bottom of the page since there isn't enough content to fill the vertical space (`/blog` and `/experiments`). Not sure if this was intentional or not, but here is a simple pr to have your footers stick to the bottom of the page using some existing tailwindcss classes.

<!-- Fixes # (issue) -->

## Type of change

<!-- Please check all items that apply (as [x]). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation only

# Checklist:

<!-- Please check all items that apply (as [x]). -->

- [x] My code follows the style and commit guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
